### PR TITLE
Fix typo which broke compilation

### DIFF
--- a/kirk_engine.h
+++ b/kirk_engine.h
@@ -1,7 +1,7 @@
 #ifndef KIRK_ENGINE
 #define KIRK_ENGINE
 
-#include "type.h"
+#include "types.h"
 
 //Kirk return values
 #define KIRK_OPERATION_SUCCESS 0


### PR DESCRIPTION
"type.h" was used when "types.h" was meant to be used.
