### PR TITLE
Fix unistd.h inclusion

### DIFF
--- a/ebootsign.c
+++ b/ebootsign.c
@@ -9,7 +9,7 @@
 #else
 #include <malloc/malloc.h>
 #endif
-#include <sys/unistd.h>
+#include <unistd.h>
 
 #if defined(_MSC_VER) || defined (__MINGW32__)
 #define mkdir(p,m) _mkdir(p)


### PR DESCRIPTION
The file sys/unistd.h is deprecated, many c libraries ship it as shim,
however musl-libc does not.